### PR TITLE
ProfileEdit 이후 토큰 재발급 구현

### DIFF
--- a/src/main/java/com/example/chosim/chosim/api/member/controller/MemberController.java
+++ b/src/main/java/com/example/chosim/chosim/api/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.example.chosim.chosim.api.member.dto.ProfileResponse;
 import com.example.chosim.chosim.domain.auth.service.MemberService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,8 +23,8 @@ public class MemberController {
 
     @PostMapping("/join")
     @Operation(summary = "프로필 입력 회원가입", description = "소셜 로그인 후 프로필 정보를 입력합니다.")
-    public ResponseEntity<Void> joinMember(@AuthenticationPrincipal Long memberId, @RequestBody ProfileRequest request){
-        memberService.joinMember(request, memberId);
+    public ResponseEntity<Void> joinMember(@AuthenticationPrincipal Long memberId, @RequestBody ProfileRequest request, HttpServletResponse response){
+        memberService.joinMember(request, memberId, response);
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 

--- a/src/main/java/com/example/chosim/chosim/common/auth/CustomOauth2FailureHandler.java
+++ b/src/main/java/com/example/chosim/chosim/common/auth/CustomOauth2FailureHandler.java
@@ -1,0 +1,43 @@
+package com.example.chosim.chosim.common.auth;
+
+import com.example.chosim.chosim.common.error.ErrorCode;
+import com.example.chosim.chosim.common.error.response.ErrorResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomOauth2FailureHandler implements AuthenticationFailureHandler {
+
+    private final ObjectMapper objectMapper;
+
+    public CustomOauth2FailureHandler(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        ErrorCode errorCode = ErrorCode.LOGIN_FAIL;
+
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode, request);
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+
+        String errorBody = objectMapper.writeValueAsString(errorResponse);
+
+        response.getWriter().write(errorBody);
+    }
+}

--- a/src/main/java/com/example/chosim/chosim/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/chosim/chosim/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.example.chosim.chosim.common.config;
 
 
+import com.example.chosim.chosim.common.auth.CustomOauth2FailureHandler;
 import com.example.chosim.chosim.common.error.handler.CustomAccessDeniedHandler;
 import com.example.chosim.chosim.common.filter.JwtAuthorizationFilter;
 import com.example.chosim.chosim.common.filter.JwtExceptionFilter;
@@ -48,7 +49,8 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
-    private final CustomOauth2SuccessHandler customOauth2SuccessHandler;
+    private final CustomOauth2SuccessHandler customOAuth2SuccessHandler;
+    private final CustomOauth2FailureHandler customOAuth2FailureHandler;
     private final JwtAuthorizationFilter jwtAuthorizationFilter;
     private final MemberRepository memberRepository;
     private final CorsFilter corsFilter;
@@ -84,8 +86,8 @@ public class SecurityConfig {
                 .oauth2Login((oauth2) -> oauth2
                         .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
                                 .userService(customOAuth2UserService))
-                        .successHandler(customOauth2SuccessHandler)
-//                        .failureHandler(customFailureHandler)
+                        .successHandler(customOAuth2SuccessHandler)
+                        .failureHandler(customOAuth2FailureHandler)
                 );
 
         http


### PR DESCRIPTION
1. CustomOAuth2FailureHandler
![image](https://github.com/user-attachments/assets/eb08e4fa-d8a8-4553-83f6-fc2d085748c7)
- ErrorCode에서 Login Error 사용
- SecurityConfig에 추가

2. CustomOAuth2SuccessHandler에 분기문 추가
![image](https://github.com/user-attachments/assets/5ded9031-01fc-4424-ada0-1c2c1296a136)
- 첫 소셜로그인인 경우 header에 tempToken 집어넣어서 redirect
- 기존 로그인의 경우 refreshToken까지 저장

3. MemberService joinMember 수정
![image](https://github.com/user-attachments/assets/42f93599-ea07-4175-85f9-f3831f7d8e20)
- 따로 DTO를 만들까 했는데 ID 이외에는 보낼만한게 없어 void 반환 유지
- response 인자 추가로 header 및 쿠키 설정

4. MemberController
![image](https://github.com/user-attachments/assets/a66e4154-b05b-4f50-95f2-7001023fc497)


TODO
service, controller 에러 처리
